### PR TITLE
Fix duplicate services key in YAML

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -43,14 +43,14 @@ services:
       - key: VITE_API_URL
         value: https://cloudboost-ai-backend.onrender.com
 
+  # Redis Service
+  - type: redis
+    name: cloudboost-ai-redis
+    plan: starter
+    maxmemoryPolicy: allkeys-lru
+
 databases:
   - name: cloudboost-ai-db
     databaseName: cloudboost_ai
     user: cloudboost_ai_user
     plan: starter
-
-services:
-  - type: redis
-    name: cloudboost-ai-redis
-    plan: starter
-    maxmemoryPolicy: allkeys-lru


### PR DESCRIPTION
Consolidate `services` definitions in `render.yaml` to fix invalid YAML syntax.