### PR TITLE
Manage dependencies and build process

### DIFF
--- a/DEPLOYMENT_FIXES_SUMMARY.md
+++ b/DEPLOYMENT_FIXES_SUMMARY.md
@@ -1,0 +1,107 @@
+# Deployment Fixes Summary
+
+## Issues Resolved
+
+### 1. Backend Flask Application Context Error
+
+**Problem:** 
+- Flask app was failing with "Working outside of application context" error when running with gunicorn
+- The issue was caused by the deprecated `@app.before_first_request` decorator
+
+**Solution:**
+- Replaced `@app.before_first_request` with a proper `create_app()` function that initializes the database within an application context
+- This ensures the database tables are created properly when the app starts
+
+**Files Modified:**
+- `backend/src/main.py`
+
+**Changes:**
+```python
+# Before (deprecated approach)
+@app.before_first_request
+def startup():
+    """Initialize application on startup"""
+    try:
+        create_tables()
+        logger.info("Application started successfully")
+    except Exception as e:
+        logger.error(f"Application startup error: {e}")
+        raise
+
+# After (proper approach)
+def create_app():
+    """Create and configure the Flask application"""
+    with app.app_context():
+        try:
+            create_tables()
+            logger.info("Application started successfully")
+        except Exception as e:
+            logger.error(f"Application startup error: {e}")
+            raise
+    return app
+
+# Initialize the app
+create_app()
+```
+
+### 2. Frontend LinkedIn Icon Import Error
+
+**Problem:**
+- Frontend build was failing due to incorrect import of `LinkedIn` icon from lucide-react
+- The correct export name is `Linkedin` (lowercase 'i')
+
+**Solution:**
+- Updated the import statement to use the correct icon name
+- Updated the icon reference in the socialLinks array
+
+**Files Modified:**
+- `frontend/src/components/Footer.jsx`
+
+**Changes:**
+```javascript
+// Before (incorrect import)
+import { 
+  Zap, Globe, Mail, Phone, MapPin, ArrowRight,
+  Facebook, Twitter, LinkedIn, Instagram, Youtube
+} from 'lucide-react'
+
+// After (correct import)
+import { 
+  Zap, Globe, Mail, Phone, MapPin, ArrowRight,
+  Facebook, Twitter, Linkedin, Instagram, Youtube
+} from 'lucide-react'
+
+// Also updated the usage in socialLinks array
+const socialLinks = [
+  { name: 'Facebook', icon: Facebook, url: 'https://facebook.com' },
+  { name: 'Twitter', icon: Twitter, url: 'https://twitter.com' },
+  { name: 'LinkedIn', icon: Linkedin, url: 'https://linkedin.com' }, // Updated icon reference
+  { name: 'Instagram', icon: Instagram, url: 'https://instagram.com' },
+  { name: 'YouTube', icon: Youtube, url: 'https://youtube.com' }
+]
+```
+
+## Expected Results
+
+### Backend
+- The Flask app should now start properly with gunicorn
+- Database tables will be created during app initialization
+- No more "Working outside of application context" errors
+
+### Frontend
+- The build process should complete successfully
+- The LinkedIn icon will render correctly in the footer
+- No more import errors from lucide-react
+
+## Verification
+
+To verify the fixes:
+
+1. **Backend**: The gunicorn command should now work without application context errors
+2. **Frontend**: The build command `pnpm run build` should complete without import errors
+
+## Additional Notes
+
+- The `@app.before_first_request` decorator was deprecated in Flask 2.0+ and removed in Flask 2.2+
+- The proper way to initialize Flask applications is to use application contexts or factory patterns
+- Lucide React icon names are case-sensitive and must match the exact export names from the library

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -465,17 +465,22 @@ def missing_token_callback(error):
     return jsonify({'error': 'Authorization token is required'}), 401
 
 # Application startup
-@app.before_first_request
-def startup():
-    """Initialize application on startup"""
-    try:
-        # Create database tables
-        create_tables()
-        logger.info("Application started successfully")
-        
-    except Exception as e:
-        logger.error(f"Application startup error: {e}")
-        raise
+def create_app():
+    """Create and configure the Flask application"""
+    with app.app_context():
+        try:
+            # Create database tables
+            create_tables()
+            logger.info("Application started successfully")
+            
+        except Exception as e:
+            logger.error(f"Application startup error: {e}")
+            raise
+    
+    return app
+
+# Initialize the app
+create_app()
 
 # Welcome endpoint
 @app.route('/')

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { 
   Zap, Globe, Mail, Phone, MapPin, ArrowRight,
-  Facebook, Twitter, LinkedIn, Instagram, Youtube
+  Facebook, Twitter, Linkedin, Instagram, Youtube
 } from 'lucide-react'
 
 const Footer = () => {
@@ -56,7 +56,7 @@ const Footer = () => {
   const socialLinks = [
     { name: 'Facebook', icon: Facebook, url: 'https://facebook.com' },
     { name: 'Twitter', icon: Twitter, url: 'https://twitter.com' },
-    { name: 'LinkedIn', icon: LinkedIn, url: 'https://linkedin.com' },
+    { name: 'LinkedIn', icon: Linkedin, url: 'https://linkedin.com' },
     { name: 'Instagram', icon: Instagram, url: 'https://instagram.com' },
     { name: 'YouTube', icon: Youtube, url: 'https://youtube.com' }
   ]


### PR DESCRIPTION
Fix backend Flask application context error and frontend Lucide React icon import issue.

The Flask backend was failing to start with gunicorn due to a deprecated decorator causing "Working outside of application context" errors. The frontend build failed because the 'LinkedIn' icon was imported with incorrect casing from `lucide-react`.